### PR TITLE
Stop findConsumeView prematurely returning null

### DIFF
--- a/itemtouchhelperextension/src/main/java/com/loopeer/itemtouchhelperextension/ItemTouchHelperExtension.java
+++ b/itemtouchhelperextension/src/main/java/com/loopeer/itemtouchhelperextension/ItemTouchHelperExtension.java
@@ -437,7 +437,10 @@ public class ItemTouchHelperExtension extends RecyclerView.ItemDecoration
         for (int i = 0; i < parent.getChildCount(); i++) {
             View child = parent.getChildAt(i);
             if (child instanceof ViewGroup && child.getVisibility() == View.VISIBLE) {
-                return findConsumeView((ViewGroup) child, x, y);
+                View view = findConsumeView((ViewGroup) child, x, y);
+                if (view != null) {
+                    return view;
+                }
             } else {
                 if (isInBoundsClickable((int) x, (int) y, child)) return child;
             }


### PR DESCRIPTION
I want to add icons to my clickable action area, and want to do so by enclosing the TextViews in LinearLayouts. However, doing so meant that a click would only be performed on the first item in the layout - any clicks on subsequent items would fail. This pull request fixes that issue.