### PR TITLE
Fix ClassCastException when using non-ViewGroup view types

### DIFF
--- a/itemtouchhelperextension/src/main/java/com/loopeer/itemtouchhelperextension/ItemTouchHelperExtension.java
+++ b/itemtouchhelperextension/src/main/java/com/loopeer/itemtouchhelperextension/ItemTouchHelperExtension.java
@@ -426,8 +426,10 @@ public class ItemTouchHelperExtension extends RecyclerView.ItemDecoration
 
     private void doChildClickEvent(float x, float y) {
         if (mSelected == null) return;
-        View view = mSelected.itemView;
-        View consumeEventView = findConsumeView((ViewGroup) view, x, y);
+        View consumeEventView = mSelected.itemView;
+        if (consumeEventView instanceof ViewGroup) {
+            consumeEventView = findConsumeView((ViewGroup) consumeEventView, x, y);
+        }
         if (consumeEventView != null) {
             consumeEventView.performClick();
         }


### PR DESCRIPTION
This fixes the issue where a crash could occur if an item was clicked 
that was not a ViewGroup - such as when using a TextView for a header.